### PR TITLE
fixing crash; big oops

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -51,7 +51,7 @@ package() {
   # install -D -t "$pkgdir/usr/share/doc/$pkgname" *.doc
   install -D -t "$pkgdir/usr/share/doc/$pkgname" *.html
   install -D -t "$pkgdir/usr/share/doc/$pkgname" *.pdf
-  install -D -t "$pkgdir/usr/share/doc/$pkgname" *.txt
+  # install -D -t "$pkgdir/usr/share/doc/$pkgname" *.txt uncomment this only if you converted .doc to .txt
 
   echo "Entering directory $srcdir/simh."
   cd "$srcdir/simh"


### PR DESCRIPTION
Just tested. It crashes because it has no .txt in the `doc` directory.
(i didn't know it would do that, i thought it will just skip them.)
**Very sorry** for the annoyance. now you have to merge this too, to build correctly.
I tested it, and it builds successfully.
oo