### PR TITLE
Build missing pdf documentation

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer emeritus: R. van Elst <https://raymii.org>
 
 pkgname="simh-git"
-pkgver=4.0.Beta.1.2676.gfc5bda90
+pkgver=4.0.Beta.1.3517.g62c0daf8
 pkgrel=1
 pkgdesc="The Computer History Simulation Project"
 arch=('i686' 'x86_64')
@@ -49,6 +49,7 @@ package() {
   cd "$srcdir/simh/doc"
   unoconv -d document --format=html *.doc
   unoconv -d document --format=txt *.doc
+  unoconv -d document --format=pdf *.doc
   # install -D -t "$pkgdir/usr/share/doc/$pkgname" *.doc
   install -D -t "$pkgdir/usr/share/doc/$pkgname" *.html
   install -D -t "$pkgdir/usr/share/doc/$pkgname" *.pdf


### PR DESCRIPTION
Seems like PDF documentation has been removed form upstream, and now installation fails at
`install -D -t "$pkgdir/usr/share/doc/$pkgname" *.pdf`
I had added the code to generate those files from doc, same way as the other files.